### PR TITLE
Add CMake option for building in headless mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 add_subdirectory(source/Irrlicht)
 
+option(BUILD_HEADLESS "Build in headless mode" ON)
 option(BUILD_EXAMPLES "Build example applications" FALSE)
 if(BUILD_EXAMPLES)
 	add_subdirectory(examples)

--- a/include/IrrCompileConfig.h
+++ b/include/IrrCompileConfig.h
@@ -44,9 +44,9 @@
 //! different library versions without having to change the sources.
 //! Example: NO_IRR_COMPILE_WITH_X11_ would disable X11
 
-// #if BUILD_HEADLESS
+#ifdef BUILD_HEADLESS
 #define _IRR_COMPILE_WITH_SDL_DEVICE_
-// #endif
+#endif
 #ifdef NO_IRR_COMPILE_WITH_SDL_DEVICE_
 #undef _IRR_COMPILE_WITH_SDL_DEVICE_
 #endif

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -100,10 +100,8 @@ if(SDL_ENABLED)
 	message(STATUS "Found SDL2: ${SDL2_LIBRARIES}")
 endif()
 if(BUILD_HEADLESS)
-    # always require SDL for headless build
-    find_package(SDL2 REQUIRED)
-    # SDL won't be included in source code unless defined
-    add_definitions(-D_IRR_BUILD_WITH_SDL_DRIVER_) # I forget what the define is actually called
+	find_package(SDL2 REQUIRED)
+	add_definitions(-DBUILD_HEADLESS=1)
 endif()
 
 # Platform-specific libs


### PR DESCRIPTION
Adds the option `BUILD_HEADLESS` to Irrlicht, which is true by default. When the option is set to a truthy value, the symbol `BUILD_HEADLESS` will be defined as `1` for the preprocessor, enabling the SDL driver as well as any code specific to headless mode.