### PR TITLE
fix sdl2 dep

### DIFF
--- a/include/IrrCompileConfig.h
+++ b/include/IrrCompileConfig.h
@@ -44,9 +44,9 @@
 //! different library versions without having to change the sources.
 //! Example: NO_IRR_COMPILE_WITH_X11_ would disable X11
 
-// #if BUILD_HEADLESS
+#if BUILD_HEADLESS
 #define _IRR_COMPILE_WITH_SDL_DEVICE_
-// #endif
+#endif
 #ifdef NO_IRR_COMPILE_WITH_SDL_DEVICE_
 #undef _IRR_COMPILE_WITH_SDL_DEVICE_
 #endif


### PR DESCRIPTION
enables BUILD_HEADLESS to control the SDL2 dependency for Irrlicht