### PR TITLE
fix macos build

### DIFF
--- a/include/irrUString.h
+++ b/include/irrUString.h
@@ -3678,7 +3678,7 @@ namespace unicode
 
 //! Hashing algorithm for hashing a ustring.  Used for things like unordered_maps.
 //! Algorithm taken from std::hash<std::string>.
-class hash : public std::unary_function<core::ustring, size_t>
+class hash
 {
 	public:
 		size_t operator()(const core::ustring& s) const


### PR DESCRIPTION
remove reference to std::unary_function
